### PR TITLE
feat: normalized CID

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -30,7 +30,7 @@ CREATE SCHEMA web3storage
     auth_key_id bigint,
     content_cid TEXT NOT NULL,
     -- CID for content as provided by the user
-    cid TEXT NOT NULL,
+    source_cid TEXT NOT NULL,
     name TEXT,
     type upload_type NOT NULL,
     inserted_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL,

--- a/schema.sql
+++ b/schema.sql
@@ -28,15 +28,17 @@ CREATE SCHEMA web3storage
     id BIGSERIAL PRIMARY KEY,
     user_id bigint NOT NULL,
     auth_key_id bigint,
-    content_id bigint NOT NULL,
+    content_cid TEXT NOT NULL,
+    -- CID for content as provided by the user
+    cid TEXT NOT NULL,
     name TEXT,
     type upload_type NOT NULL,
     inserted_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL,
     deleted_at timestamp with time zone DEFAULT timezone('utc'::text, now())
   )
   CREATE TABLE content (
-    id BIGSERIAL PRIMARY KEY,
-    cid TEXT UNIQUE NOT NULL,
+    -- normalized base32 v1
+    cid TEXT PRIMARY KEY,
     dag_size bigint DEFAULT 0,
     inserted_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL,
     updated_at timestamp with time zone  DEFAULT timezone('utc'::text, now())

--- a/schema.sql
+++ b/schema.sql
@@ -59,7 +59,7 @@ CREATE SCHEMA web3storage
   )
   CREATE TABLE pin (
     id BIGSERIAL PRIMARY KEY,
-    content_id bigint NOT NULL,
+    content_cid TEXT NOT NULL,
     pin_location_id bigint NOT NULL,
     status pin_status NOT NULL,
     inserted_at timestamp with time zone DEFAULT timezone('utc'::text, now()) NOT NULL,
@@ -73,7 +73,7 @@ CREATE SCHEMA web3storage
   )
   CREATE TABLE aggregate_entry (
     id BIGSERIAL PRIMARY KEY,
-    content_id bigint NOT NULL,
+    content_cid TEXT NOT NULL,
     aggregate_id bigint NOT NULL,
     data_model_selector TEXT
   )


### PR DESCRIPTION
As discussed, this PR makes the CID the primary key in `content`. It will be normalized as v1 b32. This is prehaps not the most efficient format for strorage/indexing (alternative was `BYTEA`) but is significantly easier to query and display as a `TEXT` field.

It also adds a `cid` column to the `upload` table for recording the CID as the user uploaded it (e.g may be a v0).

fixes https://github.com/web3-storage/web3.storage/issues/438